### PR TITLE
Update index.ts

### DIFF
--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -5,7 +5,6 @@ import { fontWeights, letterSpacings, lineHeights } from "./typography";
 
 const chakraTheme: Theme = extendTheme({
   config: {
-    initialColorMode: "dark",
     useSystemColorMode: false,
   } as Theme["config"],
   fonts: {


### PR DESCRIPTION
See the screenshot below. The widget already takes in a flag for whether it should be in dark mode or light mode, so we shouldn't enforce dark mode like this because the corners end up rendering with this weird black excess coloring.

![image](https://user-images.githubusercontent.com/987031/181655111-453ae0cc-56e6-4e83-ae2b-d22c09b5f3ea.png)
