### PR TITLE
[ERC721] Disable mint button and show text accordingly if supply is zero | Issue #58

### DIFF
--- a/src/shared/claim-button-erc721.tsx
+++ b/src/shared/claim-button-erc721.tsx
@@ -70,6 +70,8 @@ export const ERC721ClaimButton: React.FC<ClaimButtonProps> = ({
       .toString();
   }, [claimedSupply.data, unclaimedSupply.data]);
 
+  const supplyIsZero = numberTotal === "0";
+
   const priceToMint = useMemo(() => {
     const bnPrice = BigNumber.from(
       activeClaimCondition.data?.currencyMetadata.value || 0,
@@ -195,6 +197,10 @@ export const ERC721ClaimButton: React.FC<ClaimButtonProps> = ({
     [claimIneligibilityReasons.isLoading, isLoading],
   );
   const buttonText = useMemo(() => {
+    if (supplyIsZero) {
+      return "No item to mint";
+    }
+
     if (isSoldOut) {
       return "Sold Out";
     }
@@ -297,7 +303,7 @@ export const ERC721ClaimButton: React.FC<ClaimButtonProps> = ({
           theme={colorScheme}
           contractAddress={contract?.getAddress() || ""}
           action={(cntr) => cntr.erc721.claim(quantity)}
-          isDisabled={!canClaim || buttonLoading}
+          isDisabled={!canClaim || buttonLoading || supplyIsZero}
           onError={(err) => {
             console.error(err);
             toast({


### PR DESCRIPTION
When the supply is zero (no NFT added), the Mint button should be disabled, and its text should says "No item to mint"